### PR TITLE
Make bn.js a normal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mocha": "^2.0.1"
   },
   "dependencies": {
-    "bn.js": "^0.16.0"
+    "bn.js": "^0.16.0",
     "brorand": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,10 +25,8 @@
     "bn.js": "^0.16.0",
     "mocha": "^2.0.1"
   },
-  "peerDependencies": {
-    "bn.js": "^0.16.0"
-  },
   "dependencies": {
+    "bn.js": "^0.16.0"
     "brorand": "^1.0.1"
   }
 }


### PR DESCRIPTION
This should fix https://github.com/substack/node-browserify/issues/1049.
